### PR TITLE
Add short descriptions of academic talks, add links down to their track, minor update to general tracks

### DIFF
--- a/_includes/css/sotm2019.css
+++ b/_includes/css/sotm2019.css
@@ -798,3 +798,21 @@ img.noRecordingDark {
     margin-right: 10px;
     margin-bottom: 0px;
 }
+
+/* abstracts of sessions */
+.abstract-time {
+    font-size: 20px;
+}
+
+.abstract-speaker {
+    font-size: 18px;
+}
+
+.abstract-speaker,
+.abstract-no-recording {
+    font-style: italic;
+}
+
+.abstract-no-recording {
+    margin-left: 20px;
+}

--- a/_includes/schedule/_academic.html
+++ b/_includes/schedule/_academic.html
@@ -11,7 +11,7 @@
                 <tr>
                         <td class="fill-darken0">09:00</td>
                         <td rowspan="1" id="session_RZXQP3">
-        Bridging the Map? Exploring Interactions between the Academic and Mapping Communities in OpenStreetMap
+        <a href="/sessions/RZXQP3">Bridging the Map? Exploring Interactions between the Academic and Mapping Communities in OpenStreetMap</a>
     <br><span class="speaker">Yair Grinberger
     </span>
 </td>
@@ -20,7 +20,7 @@
                                 <tr>
                         <td class="fill-darken0">09:30</td>
                         <td rowspan="1" id="session_SR88Y3">
-    <img class="noRecordingDark" src="/img/novideo-dark.svg" height="25" alt="no recording" title="This event will not be recorded.">    OpenStreetMap as Space
+    <img class="noRecordingDark" src="/img/novideo-dark.svg" height="25" alt="no recording" title="This event will not be recorded.">    <a href="/sessions/SR88Y3">OpenStreetMap as Space</a>
     <br><span class="speaker">Dipto Sarkar
     </span>
 </td>
@@ -29,7 +29,7 @@
                                 <tr>
                         <td class="fill-darken0">10:00</td>
                         <td rowspan="1" id="session_GRR3N3">
-        Analysis of OSM data through OSM-Notes user posting
+        <a href="/sessions/GRR3N3">Analysis of OSM data through OSM-Notes user posting</a>
     <br><span class="speaker">Toshikazu Seto
     </span>
 </td>
@@ -38,7 +38,7 @@
                                 <tr>
                         <td class="fill-darken0">10:30</td>
                         <td rowspan="1" id="session_7ZVYEH">
-        A novel application of models of species abundance to better understand OpenStreetMap Community structure and interactions
+        <a href="/sessions/7ZVYEH">A novel application of models of species abundance to better understand OpenStreetMap Community structure and interactions</a>
     <br><span class="speaker">Peter Mooney
     </span>
 </td>
@@ -51,7 +51,7 @@
                                 <tr>
                         <td class="fill-darken0">11:30</td>
                         <td rowspan="1" id="session_TMGNLL">
-    <img class="noRecordingDark" src="/img/novideo-dark.svg" height="25" alt="no recording" title="This event will not be recorded.">    Towards Scalable Geospatial Remote Sensing for Efficient OSM Labeling
+    <img class="noRecordingDark" src="/img/novideo-dark.svg" height="25" alt="no recording" title="This event will not be recorded.">    <a href="/sessions/TMGNLL">Towards Scalable Geospatial Remote Sensing for Efficient OSM Labeling</a>
     <br><span class="speaker">Rui Zhang, Marcus Freitag
     </span>
 </td>
@@ -60,7 +60,7 @@
                                 <tr>
                         <td class="fill-darken0">12:00</td>
                         <td rowspan="1" id="session_FQPFTP">
-        Estimating latent energy demand of buildings
+        <a href="/sessions/FQPFTP">Estimating latent energy demand of buildings</a>
     <br><span class="speaker">Milojevic-Dupont Nikola, Steffen Lohrey
     </span>
 </td>
@@ -69,7 +69,7 @@
                                 <tr>
                         <td class="fill-darken0">12:30</td>
                         <td rowspan="1" id="session_GRJC7W">
-        Client-side route planning: preprocessing the OpenStreetMap road network for Routable Tiles
+        <a href="/sessions/GRJC7W">Client-side route planning: preprocessing the OpenStreetMap road network for Routable Tiles</a>
     <br><span class="speaker">Harm Delva
     </span>
 </td>
@@ -82,7 +82,7 @@
                                 <tr>
                         <td class="fill-darken0">14:00</td>
                         <td rowspan="1" id="session_F7ANUJ">
-        Intrinsic assessment of OpenStreetMap contribution patterns through Exploratory Spatial Data Analysis
+        <a href="/sessions/F7ANUJ">Intrinsic assessment of OpenStreetMap contribution patterns through Exploratory Spatial Data Analysis</a>
     <br><span class="speaker">Marco Minghini
     </span>
 </td>
@@ -91,7 +91,7 @@
                                 <tr>
                         <td class="fill-darken0">14:30</td>
                         <td rowspan="1" id="session_W8BA9K">
-        Corporate Editors in the Evolving Landscape of OpenStreetMap:  A Close Investigation of the Impact to the Map &amp; Community
+        <a href="/sessions/W8BA9K">Corporate Editors in the Evolving Landscape of OpenStreetMap:  A Close Investigation of the Impact to the Map &amp; Community</a>
     <br><span class="speaker">Jennings Anderson
     </span>
 </td>
@@ -100,7 +100,7 @@
                                 <tr>
                         <td class="fill-darken0">15:00</td>
                         <td rowspan="1" id="session_VPXQAV">
-        Exploring the Effects of Pokémon Go Vandalism on OpenStreetMap
+        <a href="/sessions/VPXQAV">Exploring the Effects of Pokémon Go Vandalism on OpenStreetMap</a>
     <br><span class="speaker">Levente Juhász
     </span>
 </td>
@@ -109,7 +109,7 @@
                                 <tr>
                         <td class="fill-darken0">15:30</td>
                         <td rowspan="1" id="session_9NVD77">
-        Analyzing the spatio-temporal patterns and impacts of large-scale data production events in OpenStreetMap
+        <a href="/sessions/9NVD77">Analyzing the spatio-temporal patterns and impacts of large-scale data production events in OpenStreetMap</a>
     <br><span class="speaker">Yair Grinberger
     </span>
 </td>
@@ -122,7 +122,7 @@
                                 <tr>
                         <td class="fill-darken0">16:30</td>
                         <td rowspan="1" id="session_LKLEWQ">
-        Development after Displacement: Using OSM data to measure SDG indicators at informal settlements
+        <a href="/sessions/LKLEWQ">Development after Displacement: Using OSM data to measure SDG indicators at informal settlements</a>
     <br><span class="speaker">Hannah Friedrich
     </span>
 </td>
@@ -131,7 +131,7 @@
                                 <tr>
                         <td class="fill-darken0">17:00</td>
                         <td rowspan="1" id="session_MWS9ZC">
-        Analysis of OpenStreetMap data quality at different stages of a participatory mapping process: Evidence from informal urban settings
+        <a href="/sessions/MWS9ZC">Analysis of OpenStreetMap data quality at different stages of a participatory mapping process: Evidence from informal urban settings</a>
     <br><span class="speaker">Godwin Yeboah
     </span>
 </td>
@@ -140,7 +140,7 @@
                                 <tr>
                         <td class="fill-darken0">17:30</td>
                         <td rowspan="1" id="session_WTWQYC">
-        Assessing the Completeness of Urban Green Spaces in OpenStreetMap
+        <a href="/sessions/WTWQYC">Assessing the Completeness of Urban Green Spaces in OpenStreetMap</a>
     <br><span class="speaker">Christina Ludwig
     </span>
 </td>

--- a/_includes/schedule/_general.html
+++ b/_includes/schedule/_general.html
@@ -39,7 +39,7 @@
                         <td class="fill-darken0">10:30</td>
                         <td rowspan="1" id="session_VC8ESD">
         Keynote
-    <br><span class="speaker">SotM Working Group
+    <br><span class="speaker">Karen M. Sandler
     </span>
 </td>
 
@@ -261,7 +261,7 @@
                         <td class="fill-darken0">09:00</td>
                         <td></td>
                             <td></td>
-                            <td>Academic track</td>
+                            <td><a href="#academic_track">Academic track</a></td>
                             <td></td>
                             <td></td>
                                                 </tr>
@@ -279,7 +279,7 @@
     </span>
 </td>
 
-                            <td>Academic track</td>
+                            <td><a href="#academic_track">Academic track</a></td>
                             <td></td>
                             <td></td>
                                                 </tr>
@@ -297,7 +297,7 @@
     </span>
 </td>
 
-                            <td>Academic track</td>
+                            <td><a href="#academic_track">Academic track</a></td>
                             <td rowspan="1" id="session_PRHPXV">
         Lightning Talks Scholars I
     <br><span class="speaker">SotM Scholars
@@ -320,7 +320,7 @@
     </span>
 </td>
 
-                            <td>Academic track</td>
+                            <td><a href="#academic_track">Academic track</a></td>
                             <td rowspan="1" id="session_M9BN97">
         Lightning Talks Scholars II
     <br><span class="speaker">SotM Scholars
@@ -347,7 +347,7 @@
     </span>
 </td>
 
-                            <td>Academic track</td>
+                            <td><a href="#academic_track">Academic track</a></td>
                             <td rowspan="3" id="session_NCSSPK">
         Bilingual Breakout Session
     <br><span class="speaker">Séverin Menard, Nicolas Chavent
@@ -375,7 +375,7 @@
     </span>
 </td>
 
-                            <td>Academic track</td>
+                            <td><a href="#academic_track">Academic track</a></td>
                             
                             
                                                 </tr>
@@ -393,7 +393,7 @@
     </span>
 </td>
 
-                            <td>Academic track</td>
+                            <td><a href="#academic_track">Academic track</a></td>
                             
                             <td></td>
                                                 </tr>
@@ -415,7 +415,7 @@
     </span>
 </td>
 
-                            <td>Academic track</td>
+                            <td><a href="#academic_track">Academic track</a></td>
                             <td rowspan="2" id="session_Z7L9HF">
         Diversity and Inclusion in OSM
     <br><span class="speaker">Patricia Solis, Miriam Gonzalez, Heather Leson
@@ -443,7 +443,7 @@
     </span>
 </td>
 
-                            <td>Academic track</td>
+                            <td><a href="#academic_track">Academic track</a></td>
                             
                             
                                                 </tr>
@@ -461,7 +461,7 @@
     </span>
 </td>
 
-                            <td>Academic track</td>
+                            <td><a href="#academic_track">Academic track</a></td>
                             <td rowspan="2" id="session_8GY9WF">
         Local Chapters Congress
     <br><span class="speaker">Joost Schouppe
@@ -479,7 +479,7 @@
 </td>
 
                             
-                            <td>Academic track</td>
+                            <td><a href="#academic_track">Academic track</a></td>
                             
                             <td></td>
                                                 </tr>
@@ -501,7 +501,7 @@
     </span>
 </td>
 
-                            <td>Academic track</td>
+                            <td><a href="#academic_track">Academic track</a></td>
                             <td rowspan="1" id="session_GXKF3F">
         Lightning Talks Scholars III
     <br><span class="speaker">SotM Scholars
@@ -524,7 +524,7 @@
     </span>
 </td>
 
-                            <td>Academic track</td>
+                            <td><a href="#academic_track">Academic track</a></td>
                             <td rowspan="2" id="session_DKVXZK">
         Nomad Maps, an andean cartographic itinerancy by bike
     <br><span class="speaker">Alban Vivert
@@ -547,7 +547,7 @@
     </span>
 </td>
 
-                            <td>Academic track</td>
+                            <td><a href="#academic_track">Academic track</a></td>
                             
                             <td></td>
                                                 </tr>

--- a/_layouts/session.html
+++ b/_layouts/session.html
@@ -1,0 +1,23 @@
+---
+layout: default
+color: no-logo program-page
+color: dark-nav
+---
+<div class='keyline-top pad8y program-page'>
+  <div class='limiter'>
+    <div class='pad4y col12 clearfix prose min-height'>
+          <p><a href='/program/#session_{{page.code}}'>Back to schedule</a></p>
+          <h1>{{page.title}}</h1>
+          <p>
+            <span class='abstract-time'>{{page.time}}, {{page.room}}</span>
+	    {% unless page.recording %}
+            <span class='abstract-no-recording'><img src="/img/novideo-dark.svg" class="noRecordingDark" height="25" alt="no recording" title="This session will not be recorded."> This event will not be recorded.</spap>
+	    {% endunless %}
+          </p>
+          </span>
+          <p class='abstract-speaker'>{{page.speaker_names_with_affiliations | join: '<br>' }}</p>
+
+          {{content}}
+    </div>
+  </div>
+</div>

--- a/sessions/7ZVYEH.html
+++ b/sessions/7ZVYEH.html
@@ -1,0 +1,13 @@
+---
+layout: session
+academic: true
+title: "A novel application of models of species abundance to better understand OpenStreetMap Community structure and interactions"
+code: "7ZVYEH"
+speaker_names_with_affiliations: ['Peter Mooney; Department of Computer Science, Maynooth University, Co. Kildare. Ireland; peter.mooney@mu.ie']
+extra_tags:
+room: "HSW"
+length: "00:20"
+time: "Sunday, 10:30"
+recording: True
+---
+<p>The OpenStreetMap (OSM) community is a global community crossing cultures, languages, and geographical boundaries. Researchers have been working to develop automated approaches to understanding the composition of this community through their contributions to the OSM database. In this talk we propose a new and novel application of theories and models of species abundance from ecological science to understand contributor community structure and distributions in OSM.</p>

--- a/sessions/9NVD77.html
+++ b/sessions/9NVD77.html
@@ -1,0 +1,13 @@
+---
+layout: session
+academic: true
+title: "Analyzing the spatio-temporal patterns and impacts of large-scale data production events in OpenStreetMap"
+code: "9NVD77"
+speaker_names_with_affiliations: ['A. Yair Grinberger; GIScience Research Group, Heidelberg University, Im Neuenheimer Feld 348, 69120 Heidelberg, Germany; yair.grinberger@uni-heidelberg.de;', 'Moritz Schott; GIScience Research Group, Heidelberg University, Im Neuenheimer Feld 348, 69120 Heidelberg, Germany; moritz.schott@posteo.de;', 'Martin Raifer; GIScience Research Group, Heidelberg University, Im Neuenheimer Feld 348, 69120 Heidelberg, Germany; martin.raifer@uni-heidelberg.de', 'Rafael Troilo; GIScience Research Group, Heidelberg University, Im Neuenheimer Feld 348, 69120 Heidelberg, Germany; rafael.troilo@uni-heidelberg.de', 'Alexander Zipf; GIScience Research Group, Heidelberg University, Im Neuenheimer Feld 348, 69120 Heidelberg, Germany; zipf@uni-heidelberg.de;']
+extra_tags:
+room: "HSW"
+length: "00:20"
+time: "Sunday, 15:30"
+recording: True
+---
+<p>In this talk, large scale data production events in OSM are identified, characterized, and their spatio-temporal patterns and impacts are analyzed. The results show that remote mapping events produce more data today than bulk imports, yet that the former type has a more lasting impact on representation, hence pointing towards possible steps for maximizing the positive influences of events of different types.</p>

--- a/sessions/F7ANUJ.html
+++ b/sessions/F7ANUJ.html
@@ -1,0 +1,13 @@
+---
+layout: session
+academic: true
+title: "Intrinsic assessment of OpenStreetMap contribution patterns through Exploratory Spatial Data Analysis"
+code: "F7ANUJ"
+speaker_names_with_affiliations: ['Marco Minghini; European Commission, Joint Research Centre (JRC), Via Enrico Fermi 2749, 21027 Ispra, Italy; marco.minghini@ec.europa.eu;', 'Daniele Oxoli; Politecnico di Milano, Department of Civil and Environmental Engineering, Piazza Leonardo da Vinci 32, 20133 Milano, Italy; daniele.oxoli@polimi.it;', 'Francesco Frassinelli; Norsk institutt for naturforskning (NINA), Høgskoleringen, 7034 Trondheim, Norway; francesco.frassinelli@nina.no;', 'Maria Antonia Brovelli; Politecnico di Milano, Department of Civil and Environmental Engineering, Piazza Leonardo da Vinci 32, 20133 Milano, Italy; maria.brovelli@polimi.it']
+extra_tags:
+room: "HSW"
+length: "00:20"
+time: "Sunday, 14:00"
+recording: True
+---
+<p>This study adopts a statistical approach based on Exploratory Spatial Data Analysis to identify underlying contribution patterns of OpenStreetMap (OSM). Univariate and multivariate analyses on a number of variables computed from OSM history on a regular hexagonal grid in Milan (Italy) allow to detect a number of both local clusters and local outliers, which shed light on the complexity of OSM temporal evolution driven by active local contributors and communities, data imports and mapping parties.</p>

--- a/sessions/FQPFTP.html
+++ b/sessions/FQPFTP.html
@@ -1,0 +1,13 @@
+---
+layout: session
+academic: true
+title: "Estimating latent energy demand of buildings"
+code: "FQPFTP"
+speaker_names_with_affiliations: ['Nikola Milojevic-Dupont; Mercator Research Institute on Global Commons and Climate Change, Technische Universität Berlin; milojevic@mcc-berlin.net', 'Peter-Paul Pichler; Potsdam Institute for Climate Impact Research (PIK); pichler@pik-potsdam.de', 'Lynn H. Kaack; Energy Politics Group - ETH Zurich; lynn.kaack@gess.ethz.ch', 'Steffen Lohrey; Technische Universität Berlin; steffen.lohrey@campus.tu-berlin.de', 'Felix Creutzig; Mercator Research Institute on Global Commons and Climate Change, Technische Universität Berlin; creutzig@mcc-berlin.net']
+extra_tags:
+room: "HSW"
+length: "00:20"
+time: "Sunday, 12:00"
+recording: True
+---
+<p>We propose a model that uses only open data for estimating the minimal energy use of individual buildings for heating and cooling at scale. The workflow is divided in two main blocks: (i) predicting at scale a 3D building stock using OpenStreetMap data, and (ii) estimating the energy use of buildings individually with a back-end model.</p>

--- a/sessions/GRJC7W.html
+++ b/sessions/GRJC7W.html
@@ -1,0 +1,13 @@
+---
+layout: session
+academic: true
+title: "Client-side route planning: preprocessing the OpenStreetMap road network for Routable Tiles"
+code: "GRJC7W"
+speaker_names_with_affiliations: ['Harm Delva; Ghent University – imec – IDLab; harm.delva@ugent.be;', 'Julián Rojas; Ghent University - imec - IDLab; julian.rojas@ugent.be;', 'Ben Abelshausen; Open Knowledge Belgium; ben@openknowledge.be;', 'Pieter Colpaert; Ghent University – imec – IDLab; pieter.colpaert@ugent.be;', 'Ruben Verborgh; Ghent University – imec – IDLab; ruben.verborgh@ugent.be;']
+extra_tags:
+room: "HSW"
+length: "00:20"
+time: "Sunday, 12:30"
+recording: True
+---
+<p>Travelers have high expectations of their route planners. We explore how preprocessing techniques applied to Linked Open Data derived from OSM (Routable Tiles) can provide a satisfying performance for client-side route planning.</p>

--- a/sessions/GRR3N3.html
+++ b/sessions/GRR3N3.html
@@ -1,0 +1,13 @@
+---
+layout: session
+academic: true
+title: "Analysis of OSM data through OSM-Notes user posting"
+code: "GRR3N3"
+speaker_names_with_affiliations: ['Toshikazu Seto; the University of Tokyo; tosseto@csis.u-tokyo.ac.jp', 'Hiroshi Kanasugi; the University of Tokyo; yok@csis.u-tokyo.ac.jp', "Yuichiro Nishimura; Nara Women's University; nissy_yu@cc.nara-wu.ac.jp"]
+extra_tags:
+room: "HSW"
+length: "00:20"
+time: "Sunday, 10:00"
+recording: True
+---
+<p>In this research, the OSM-Notes feature is mainly viewed as data that can be examined speedily from OSM data globally in terms of the content of the notes posted and the location of users.</p>

--- a/sessions/LKLEWQ.html
+++ b/sessions/LKLEWQ.html
@@ -1,0 +1,13 @@
+---
+layout: session
+academic: true
+title: "Development after Displacement: Using OSM data to measure SDG indicators at informal settlements"
+code: "LKLEWQ"
+speaker_names_with_affiliations: ['Hannah Friedrich; Oregon State University; friedrih@oregonstate.edu', 'Jamon Van Den Hoek; Oregon State University; vandenhj@oregonstate.edu ', 'David Wrathall; Oregon State University; wrathald@oregonstate.edu ', 'Anna Ballasiotes; Oregon State University; ballasia@oregonstate.edu']
+extra_tags:
+room: "HSW"
+length: "00:20"
+time: "Sunday, 16:30"
+recording: True
+---
+<p>There are 250 million refugees and IDPs in informal settlements that are routinely excluded from population and settlement datasets as well as Sustainable Development Goals (SDGs) assessments. Here, we share results from ongoing research to map and assess SDG indicators at global informal settlements using OSM data and satellite imagery. We present a new OSM-driven schema for monitoring SDG progress that counters the exclusion of informal settlements from other assessments.</p>

--- a/sessions/MWS9ZC.html
+++ b/sessions/MWS9ZC.html
@@ -1,0 +1,13 @@
+---
+layout: session
+academic: true
+title: "Analysis of OpenStreetMap data quality at different stages of a participatory mapping process: Evidence from informal urban settings"
+code: "MWS9ZC"
+speaker_names_with_affiliations: ['Godwin Yeboah; Institute for Global Sustainable Development, University of Warwick, UK; G.Yeboah@warwick.ac.uk;', 'Rafael Troilo; GIScience Research Group, Heidelberg Institute for Geoinformation Technology, Heidelberg University, Germany; Rafael.Troilo@uni-heidelberg.de;', 'Vangelis Pitidis; Institute for Global Sustainable Development, University of Warwick, UK; V.Pitidis@warwick.ac.uk;', 'João Porto de Albuquerque; Institute for Global Sustainable Development, University of Warwick, UK; J.Porto@warwick.ac.uk;']
+extra_tags:
+room: "HSW"
+length: "00:20"
+time: "Sunday, 17:00"
+recording: True
+---
+<p>This study examines OpenStreetMap data quality at different stages of a participatory mapping process developed for understanding inequalities in healthcare access of informal urban residents in Africa and Asia. Recent studies have examined quality intrinsically and extrinsically. However, in both cases, the data production processes are often not completely transparent to researchers, therefore limiting possibilities for systematic data quality analysis of the processes leading to OpenStreetMap update.</p>

--- a/sessions/RZXQP3.html
+++ b/sessions/RZXQP3.html
@@ -1,0 +1,13 @@
+---
+layout: session
+academic: true
+title: "Bridging the Map? Exploring Interactions between the Academic and Mapping Communities in OpenStreetMap"
+code: "RZXQP3"
+speaker_names_with_affiliations: ['A. Yair Grinberger; GIScience Research Group, Heidelberg University, Im Neuenheimer Feld 348, 69120 Heidelberg, Germany; yair.grinberger@uni-heidelberg.de;', 'Marco Minghini; European Commission, Joint Research Centre (JRC), Via Enrico Fermi 2749, 21027 Ispra, Italy; marco.minghini@ec.europa.eu;', 'Levente Juhász; GIS Center, Florida International University, 11200 SW 8th St, Miami, FL 33199, USA; ljuhasz@fiu.edu;', 'Peter Mooney; Department of Computer Science, Maynooth University, Maynooth, Co. Kildare. Ireland W23 F2H6; peter.mooney@mu.ie;', 'Godwin Yeboah; Institute for Global Sustainable Development, School of Cross-faculty Studies, University of Warwick, Coventry, CV4 7AL, United Kingdom; g.yeboah@warwick.ac.uk;']
+extra_tags:
+room: "HSW"
+length: "00:20"
+time: "Sunday, 09:00"
+recording: True
+---
+<p>This talk presents an initial inquiry into the relations between the Academic and Mapping communities in OpenStreetMap, based on a review of recent publications, interviews of colleagues, and self-reflection of the authors. By this, we aim to understand how and when research-community interactions come to be, what is their nature, and how can these be improved and made more productive for both sides.</p>

--- a/sessions/SR88Y3.html
+++ b/sessions/SR88Y3.html
@@ -1,0 +1,13 @@
+---
+layout: session
+academic: true
+title: "OpenStreetMap as Space"
+code: "SR88Y3"
+speaker_names_with_affiliations: ['Dipto Sarkar. National University of Singapore. dipto.sarkar@mail.mcgill.ca / dipto.sarkar@nus.edu.sg;', 'So Hoi Kay. National University of Singapore. e0202937@u.nus.edu']
+extra_tags:
+room: "HSW"
+length: "00:20"
+time: "Sunday, 09:30"
+recording: False
+---
+<p>Can OSM be used in classroom teaching as a definitive instance of a geographic space? We provide instances of how OSM as space may be of interest to researchers and for students of geography alike. Concepts of human geography manifested in OSM can be used to understand how digital geographies and offline activities are intrinsically interwoven with and influenced by each other. Thus, introduction to digital geography in classrooms can be through concepts in human geography.</p>

--- a/sessions/TMGNLL.html
+++ b/sessions/TMGNLL.html
@@ -1,0 +1,13 @@
+---
+layout: session
+academic: true
+title: "Towards Scalable Geospatial Remote Sensing for Efficient OSM Labeling"
+code: "TMGNLL"
+speaker_names_with_affiliations: ['Rui Zhang; rui.zhang@ibm.com; IBM Research*', 'Marcus Freitag; mfreitag@us.ibm.com; IBM Research*', 'Conrad Albrecht; cmalbrec@us.ibm.com; IBM Research*', 'Siyuan Lu; lus@us.ibm.com; IBM Research*', 'Wei Zhang; weiz@us.ibm.com; IBM Research*', '', '*TJ Watson Research Center, 1101 Kitchawan Rd, Yorktown Heights, NY 10598, U.S.A.']
+extra_tags:
+room: "HSW"
+length: "00:20"
+time: "Sunday, 11:30"
+recording: False
+---
+<p>The time OSM mappers invest in labeling the world is valuable. We present how methods from remote sensing, big data distributed computing and artificial intelligence can be combined to support human analysis of geo-spatial data.</p>

--- a/sessions/VPXQAV.html
+++ b/sessions/VPXQAV.html
@@ -1,0 +1,13 @@
+---
+layout: session
+academic: true
+title: "Exploring the Effects of Pokémon Go Vandalism on OpenStreetMap"
+code: "VPXQAV"
+speaker_names_with_affiliations: ['Levente Juhász;GIS Center, Florida International University;ljuhasz@fiu.edu', 'Hartwig Hochmair;Geomatics Program, University of Florida;hhhocmair@ufl.edu', 'Sen Qiao;GIS Center, Florida International University;sqiao@fiu.edu', 'Tessio Novack;GIScience Research Group;Heidelberg University;novack@uni-heidelberg.de']
+extra_tags:
+room: "HSW"
+length: "00:20"
+time: "Sunday, 15:00"
+recording: True
+---
+<p>This presentation describes the nature and life-cycle of carto-vandalism through a data-driven analysis of harmful edits originated from Pokémon Go players. It also assesses how the OSM community reacts to vandalism.</p>

--- a/sessions/W8BA9K.html
+++ b/sessions/W8BA9K.html
@@ -1,0 +1,13 @@
+---
+layout: session
+academic: true
+title: "Corporate Editors in the Evolving Landscape of OpenStreetMap:  A Close Investigation of the Impact to the Map & Community"
+code: "W8BA9K"
+speaker_names_with_affiliations: ['Jennings Anderson; University of Colorado Boulder; jennings.anderson@colorado.edu', 'Dipto Sarkar; National University of Singapore; dipto.sarkar@nus.edu.sg', 'Leysia Palen; University of Colorado Boulder; leysia.palen@colorado.edu']
+extra_tags:
+room: "HSW"
+length: "00:20"
+time: "Sunday, 14:30"
+recording: True
+---
+<p>More than 17 million edits globally have been made by paid contributors in the last five years. We look at the long history of corporate involvement in OSM and then dig into the data to quantify the impact this latest evolution of corporate involvement is having on the map and explore the interactions between paid and volunteer mappers.</p>

--- a/sessions/WTWQYC.html
+++ b/sessions/WTWQYC.html
@@ -1,0 +1,13 @@
+---
+layout: session
+academic: true
+title: "Assessing the Completeness of Urban Green Spaces in OpenStreetMap"
+code: "WTWQYC"
+speaker_names_with_affiliations: ['Christina Ludwig, GIScience Research Group, University of Heidelberg; christina.ludwig@uni-heidelberg.de', 'Robert Hecht; Leibniz Institute of Ecological Urban and Regional Development; r.hecht@ioer.de', 'Sven Lautenbach, GIScience Research Group, University of Heidelberg; sven.lautenbach@uni-heidelberg.de']
+extra_tags:
+room: "HSW"
+length: "00:20"
+time: "Sunday, 17:30"
+recording: True
+---
+<p>OpenStreetMap provides a lot of valuable information about urban green spaces, but the numerous and conceptually overlapping OSM tags that describe such features lead to spatially heterogenous representations in OSM. We developed an exploratory data analysis methodology to identify locally relevant OSM tags for mapping green spaces in a specific area and compared the extracted OSM features to administrative data to evaluate the level of completeness in regard to urban green spaces.</p>


### PR DESCRIPTION
This pull request adds short descriptions for the academic talks.

Notes:

* The long abstracts follow once the authors have changed their abstracts according to the feedback given by the programme committee.
* The long descriptions of the speakers of the general track require some editing. AFAIK we are waiting some speakers to submit updated versions.
* The pages for talks of the general track will essentially look the same. The authors' listing will be shorter. :-)
* I would like to ask for a review of the design of the details pages and I do not ask for a blind merge. I can merge myself if I want it.