### PR TITLE
Switch to tile.openstreetmap.org

### DIFF
--- a/_includes/map.html
+++ b/_includes/map.html
@@ -9,10 +9,9 @@
 <script>
   document.addEventListener('DOMContentLoaded', function() {
     var map = L.map('map').setView([49.412, 8.690], 14);
-    L.tileLayer('https://api.openrouteservice.org/cmapsurfer/{z}/{x}/{y}.png?api_key={accessToken}', {
-      attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, Imagery © <a href="https://www.geog.uni-heidelberg.de/gis/index_en.html">GIScience Heidelberg</a> powered by <a href="http://mapsurfernet.com/">MapSurfer.NET</a>',
-      maxZoom: 18,
-      accessToken: '{{ site.orsApiKey }}'
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, map tiles © <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA 2.0</a>',
+      maxZoom: 19
     }).addTo(map);
 
     L.marker([49.41854, 8.67345], {icon: L.icon({

--- a/accommodation/index.html
+++ b/accommodation/index.html
@@ -121,10 +121,9 @@ headings: "hotels,other-hotels"
         ];
 
         var map = L.map('map').setView([49.41, 8.69], 14);
-        L.tileLayer('https://api.openrouteservice.org/cmapsurfer/{z}/{x}/{y}.png?api_key={accessToken}', {
-          attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, Imagery © <a href="https://www.geog.uni-heidelberg.de/gis/index_en.html">GIScience Heidelberg</a>',
-          maxZoom: 18,
-          accessToken: '{{ site.orsApiKey }}'
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, map tiles © <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA 2.0</a>',
+          maxZoom: 19
         }).addTo(map);
 
         map.scrollWheelZoom.disable();

--- a/venue/index.html
+++ b/venue/index.html
@@ -62,10 +62,9 @@ headings: "heidelberg,conference-venue,sights,getting-to"
     <script>
       document.addEventListener('DOMContentLoaded', function() {
         var map = L.map('map').setView([49.414, 8.68], 14);
-        L.tileLayer('https://api.openrouteservice.org/cmapsurfer/{z}/{x}/{y}.png?api_key={accessToken}', {
-          attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, Imagery © <a href="https://www.geog.uni-heidelberg.de/gis/index_en.html">GIScience Heidelberg</a>',
-          maxZoom: 18,
-          accessToken: '{{ site.orsApiKey }}'
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, map tiles © <a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA 2.0</a>',
+          maxZoom: 19
         }).addTo(map);
         map.scrollWheelZoom.disable();
         L.marker([49.41854, 8.67345], {icon: L.icon({


### PR DESCRIPTION
Reasons:

* api.openrouteservice.org is not mentioned in the OSMF Privacy Policy
* Tiles from api.openrouteservice.org have not been udpated for about 8 months (proof: have a look at the tram tracks around Heidelberg Hbf).