### PR TITLE
Change campsite link to use opencampingmap.org instead of overpass query

### DIFF
--- a/accommodation/index.html
+++ b/accommodation/index.html
@@ -56,7 +56,8 @@ headings: "hotels,other-hotels"
       <div class='space-bottom2 clearfix'>
         <h2 class='space-bottom1' id='other-hotels' title="Other Hotels">Other Hotel Bookings</h2>
         <p>Other than these pre-booked hotels, there are a large number of hotels that you can use during the conference. Aswell as staying in Heidelberg, you can also choose to stay in nearby towns and cities such as Mannheim. There are fairly regular connections between Heidelberg and Mannheim both via the local train network and using trams. There are connections throughout the night on Friday and Saturday, but limited connections on Sunday night (last train around 1am on Monday morning).</p>
-          <p>If you're on a low budget you might consider the <a href="https://www.jugendherberge.de/en/youth-hostels/heidelberg-international-10/portrait/">Youth Hostel Heidelberg International</a>, which is <a href="https://www.openstreetmap.org/way/623828907">located</a> within walking distance of the SotM conference venue. If you prefer to camp, there are a <a href="https://overpass-turbo.eu/s/HQp">few camp sites</a> not very far from Heidelberg.</p>
+          <p>If you're on a low budget you might consider the <a href="https://www.jugendherberge.de/en/youth-hostels/heidelberg-international-10/portrait/">Youth Hostel Heidelberg International</a>, which is <a href="https://www.openstreetmap.org/way/623828907">located</a> within walking distance of the SotM conference venue.
+          If you prefer to camp, there are a <a href="https://opencampingmap.org/#13/49.4013/8.7321/0/0/fff">few camp sites</a> not very far from Heidelberg.</p>
       </div>
     </div>
 


### PR DESCRIPTION
opencampingmap.org does provide a more enduser friendly interface than overpass-turbo.