### PR TITLE
Docker cleanups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,11 @@ WORKDIR /app
 ADD Gemfile* /app/
 
 # Install Gems
-RUN gem install bundler --no-document \
+RUN gem update --system \
+    && gem install bundler \
     && bundle config build.nokogiri --use-system-libraries \
-    && bundle install --jobs $(nproc) --retry 5
+    && bundle config --global jobs $(nproc) \
+    && bundle install
 
 # Copy Site Files
 COPY . .

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -13,20 +13,24 @@ WORKDIR /app
 ADD Gemfile* /app/
 
 # Install Gems
-RUN gem install bundler --no-document \
+RUN gem update --system \
+    && gem install bundler \
     && bundle config build.nokogiri --use-system-libraries \
-    && bundle install --deployment --no-cache --jobs $(nproc) --retry 5 \
+    && bundle config --global jobs $(nproc) \
+    && bundle install --deployment --no-cache \
     && bundle clean
 
 # Copy Site Files
 COPY . .
+
+ENV JEKYLL_ENV=production
 
 # Run jekyll build site
 RUN bundle exec jekyll build --verbose
 
 #-------------------------------------------------
 
-FROM nginx:stable as webserver
+FROM nginx:stable-alpine as webserver
 
 # Copy built site from build stage
 COPY --from=build /app/_site /usr/share/nginx/html


### PR DESCRIPTION
* Use smaller production image. (nginx:stable-alpine)
* Set JEKYLL_ENV=production for production builds
* Update system bundler to get rid build version warning